### PR TITLE
Defatalize warnings in module and test program

### DIFF
--- a/lib/Tree/Ops.pm
+++ b/lib/Tree/Ops.pm
@@ -7,7 +7,7 @@
 package Tree::Ops;
 our $VERSION = 20201030;
 require v5.26;
-use warnings FATAL => qw(all);
+use warnings;
 use strict;
 use Carp;
 use Data::Dump qw(dump);

--- a/test.pl
+++ b/test.pl
@@ -4,7 +4,7 @@
 # Philip R Brenan at gmail dot com, Appa Apps Ltd, 2016
 #-------------------------------------------------------------------------------
 
-use warnings FATAL => qw(all);
+use warnings;
 use strict;
 use Tree::Ops;
 


### PR DESCRIPTION
The experimental 'smartmatch' operator will be deprecated in soon-to-be-released perl-5.38.0.  That deprecation will throw a warning which, if warnings have been fatalized, will cause a build-time failure.

This patch merely defatalizes the warning.  The warning will still be omitted (e.g., during './Build test), but this buys time for avoiding use of smartmatch altogether.